### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/HCA-MCOE/20a89083-7608-45fd-a30d-eb12a3289642/fb0e190b-144a-4494-bf2e-749c04679d88/_apis/work/boardbadge/96830337-b973-4b31-ae71-2d966c591195)](https://dev.azure.com/HCA-MCOE/20a89083-7608-45fd-a30d-eb12a3289642/_boards/board/t/fb0e190b-144a-4494-bf2e-749c04679d88/Microsoft.RequirementCategory)
 # Devoted


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#49](https://dev.azure.com/HCA-MCOE/20a89083-7608-45fd-a30d-eb12a3289642/_workitems/edit/49). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.